### PR TITLE
Fix Python tests for 4.30

### DIFF
--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -1,4 +1,4 @@
-selenium==4.29.0
+selenium==4.30.0
 pytest==8.3.5
 trio==0.29.0
 pytest-trio==0.8.0

--- a/examples/python/tests/bidi/cdp/test_network.py
+++ b/examples/python/tests/bidi/cdp/test_network.py
@@ -2,7 +2,7 @@ import base64
 
 import pytest
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.devtools.v131.network import Headers
+from selenium.webdriver.common.devtools.v134.network import Headers
 
 
 @pytest.mark.trio

--- a/examples/python/tests/conftest.py
+++ b/examples/python/tests/conftest.py
@@ -14,6 +14,12 @@ import pytest
 from selenium import webdriver
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "driver_type(type): marks tests to use driver type ('bidi', 'firefox', etc)"
+    )
+
+
 @pytest.fixture(scope='function')
 def driver(request):
     marker = request.node.get_closest_marker("driver_type")


### PR DESCRIPTION
This PR should fix the issues in https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2240

- changed the import to CDP v134 to fix a test error in: `examples/python/tests/bidi/cdp/test_network.py`

- registers the `driver_type` marker. Previously this was causing 4 warnings when running the tests in `examples/python/tests/bidi/test_bidi_logging.py`

Note: There is still one failure in the tests. `tests/interactions/test_alerts.py::test_alert_popup` fails and crashes Chrome, after raising the following exception: 

```
selenium.common.exceptions.ElementClickInterceptedException: Message: element click intercepted: Element is not clickable at point (964, 583)
E         (Session info: chrome=134.0.6998.165)
```

This test also fails in 4.29.0, so it's not specific to the version bump.